### PR TITLE
Test: adicionado suporte a testes e 3 casos de teste

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,20 @@
         <artifactId>angus-mail</artifactId>
         <version>2.0.3</version>
     </dependency>
+    
+    <dependency>
+	    <groupId>org.junit.jupiter</groupId>
+	    <artifactId>junit-jupiter-api</artifactId>
+	    <version>5.10.2</version>
+	    <scope>test</scope>
+	</dependency>
+	
+	<dependency>
+	    <groupId>org.junit.jupiter</groupId>
+	    <artifactId>junit-jupiter-engine</artifactId>
+	    <version>5.10.2</version>
+	    <scope>test</scope>
+	</dependency>
   </dependencies>
 
 </project>

--- a/src/main/java/projetoAcoes/client/ApiClient.java
+++ b/src/main/java/projetoAcoes/client/ApiClient.java
@@ -1,0 +1,7 @@
+package projetoAcoes.client;
+
+import projetoAcoes.model.Acao;
+
+public interface ApiClient {
+	Acao buscarCotacao(String simbolo) throws Exception;
+}

--- a/src/main/java/projetoAcoes/client/EmailClient.java
+++ b/src/main/java/projetoAcoes/client/EmailClient.java
@@ -19,12 +19,15 @@ public class EmailClient {
     private final String port;
     private final String username;
     private final String password;
+    private int emailsEnviados;
+    private String ultimoAssunto;
 
     public EmailClient(String host, String port, String username, String password) {
         this.host = host;
         this.port = port;
         this.username = username;
         this.password = password;
+        this.emailsEnviados = 0;
     }
 
     public void enviarEmail(String destinatario, String assunto, String corpo) throws MessagingException {
@@ -54,6 +57,8 @@ public class EmailClient {
         
         // Enviar a mensagem
         Transport.send(message);
+        this.emailsEnviados++;
+        this.ultimoAssunto = assunto;
         
         System.out.println("E-mail enviado!");
     }
@@ -65,10 +70,10 @@ public class EmailClient {
     		// precoAlvo é o preco de compra ou venda do alerta
     		double precoAlvo = compraOuVenda == "compra" ? alerta.getPrecoCompra() : alerta.getPrecoVenda();
     		
-            String assunto = "[AtivosBot] Alerta de Preço para "+ compraOuVenda + " Atingido - " + acao.getSimbolo();
+            String assunto = "Alerta de Preço para "+ compraOuVenda + " atingido - " + acao.getSimbolo();
             String corpo = String.format(
-                "Olá!\n\nSeu alerta de "+ compraOuVenda +" para o ativo" + acao.getSimbolo() + "foi atingido.\n\n" +
-                "Condição para a "+ compraOuVenda +" : %s de R$%.2f\n" +
+                "Olá!\n\nSeu alerta de "+ compraOuVenda +" para o ativo " + acao.getSimbolo() + " foi atingido.\n\n" +
+                "Condição para a "+ compraOuVenda +": de R$%.2f\n" +
                 "Preço Atual: R$%.2f\n\n",
                 precoAlvo,
                 acao.getPreco()
@@ -79,6 +84,14 @@ public class EmailClient {
         	// TO-DO adicionar novas tentativas de envio de email
             System.err.println("Falha ao enviar e-mail de notificação: " + e.getMessage());
         }
+    }
+    
+    public int getEmailsEnviados() {
+        return this.emailsEnviados;
+    }
+
+    public String getUltimoAssunto() {
+        return this.ultimoAssunto;
     }
     
 }

--- a/src/main/java/projetoAcoes/client/FinnhubClient.java
+++ b/src/main/java/projetoAcoes/client/FinnhubClient.java
@@ -11,7 +11,7 @@ import com.google.gson.JsonObject;
 
 import projetoAcoes.model.Acao;
 
-public class FinnhubClient {
+public class FinnhubClient implements ApiClient{
 
 	private final String APIKey;
 	private final String BaseURL = "https://finnhub.io/api/v1";
@@ -32,6 +32,7 @@ public class FinnhubClient {
      * @throws IOException
      * @throws InterruptedException
      */
+    @Override
     public Acao buscarCotacao(String acao) throws IOException, InterruptedException {
         // 1. Monta a URL específica para a Finnhub
         String url = String.format("%s/quote?symbol=%s&token=%s",

--- a/src/main/java/projetoAcoes/service/MonitorService.java
+++ b/src/main/java/projetoAcoes/service/MonitorService.java
@@ -4,8 +4,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import projetoAcoes.client.ApiClient;
 import projetoAcoes.client.EmailClient;
-import projetoAcoes.client.FinnhubClient;
 import projetoAcoes.model.Acao;
 import projetoAcoes.model.AlertaPreco;
 
@@ -15,14 +15,14 @@ public class MonitorService {
 	
     private AlertaPreco alerta;
     
-    private final FinnhubClient apiClient;
+    private final ApiClient apiClient;
     private final EmailClient emailClient;
     private final String emailDestinatario;
 
     // O agendador que executará a verificação periodicamente
     private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
 
-    public MonitorService(FinnhubClient apiClient, EmailClient emailClient, String emailDestinatario) {
+    public MonitorService(ApiClient apiClient, EmailClient emailClient, String emailDestinatario) {
         this.apiClient = apiClient;
         this.emailClient = emailClient;
         this.emailDestinatario = emailDestinatario;
@@ -52,7 +52,7 @@ public class MonitorService {
      * Função que é executada pelo scheduler no intervalo de tempo definido.
      * Verifica se o preço de compra ou venda foi atingido.
      */
-    private void verificarAlerta() {
+    public void verificarAlerta() {
 
 		try {
 			// Busca o preço atual do ativo

--- a/src/test/java/projetoAcoes/client/MockApiClient.java
+++ b/src/test/java/projetoAcoes/client/MockApiClient.java
@@ -1,0 +1,28 @@
+
+package projetoAcoes.client;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import projetoAcoes.model.Acao;
+
+public class MockApiClient implements ApiClient {
+
+    private final Map<String, Acao> precosSimulados = new HashMap<>();
+
+    @Override
+    public Acao buscarCotacao(String simbolo) throws Exception {
+        if (precosSimulados.containsKey(simbolo)) {
+            System.out.println("[MOCK API] Retornando preço simulado para " + simbolo);
+            return precosSimulados.get(simbolo);
+        }
+        throw new Exception("Ativo não encontrado no mock: " + simbolo);
+    }
+
+    /**
+     * Método de controle para nossos testes. Usamos para definir o preço que o mock deve retornar.
+     */
+    public void setPrecoSimulado(String simbolo, double preco, String variacao) {
+        this.precosSimulados.put(simbolo, new Acao(simbolo, preco, variacao));
+    }
+}

--- a/src/test/java/projetoAcoes/client/MonitorServiceTest.java
+++ b/src/test/java/projetoAcoes/client/MonitorServiceTest.java
@@ -1,0 +1,86 @@
+package projetoAcoes.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.github.cdimascio.dotenv.Dotenv;
+import projetoAcoes.model.AlertaPreco;
+import projetoAcoes.service.MonitorService;
+
+public class MonitorServiceTest {
+
+	private MockApiClient mockApi;
+	private EmailClient emailClient;
+	private MonitorService monitorService;
+
+	@BeforeEach
+	void setUp() {
+		// Roda antes de todos os testes
+		Dotenv dotenv = Dotenv.load();
+		this.mockApi = new MockApiClient();
+		this.emailClient = new EmailClient(
+	            dotenv.get("EMAIL_HOST"),
+	            dotenv.get("EMAIL_PORT"),
+	            dotenv.get("EMAIL_USERNAME"),
+	            dotenv.get("EMAIL_PASSWORD")
+	        );
+		
+		monitorService = new MonitorService(mockApi, emailClient, dotenv.get("EMAIL_DESTINO"));
+		
+		// descomente e comente a linha superior se quiser utilizar um email fake para testes
+//		this.monitorService = new MonitorService(mockApi, emailClient, "exemplo@teste.com");
+	}
+
+	@Test
+	void deveEnviarEmailQuandoAlertaDeAltaEAtingido() {
+		// ARRANGE (Preparação)
+		// Cenário: O alerta é para quando PETR4 subir acima de 240.0.
+		monitorService.setAlerta(new AlertaPreco("AAPL", 240, 230));
+		
+		// Simulação: O preço atual da AAPL é 241.
+		mockApi.setPrecoSimulado("AAPL", 241, "+2.5%");
+
+		// ACT (Ação)
+		// Executamos a lógica que queremos testar.
+		monitorService.verificarAlerta();
+
+		// ASSERT (Verificação)
+		// Verificamos se o resultado esperado aconteceu.
+		assertEquals(1, emailClient.getEmailsEnviados(), "Um e-mail deveria ter sido enviado.");
+		assertTrue(emailClient.getUltimoAssunto().contains("Alerta de Preço para venda atingido - AAPL"));
+	}
+
+	@Test
+	void naoDeveEnviarEmailQuandoAlertaDeAltaNaoEAtingido() {
+	    
+	    // Cenário: Alerta para PETR4 acima de 40 e abaixo de 30
+	    monitorService.setAlerta(new AlertaPreco("PETR4.SA", 40.0, 30.0));
+	    
+	    // Simulação: O preço atual é 37.25 e dentro do intervalo.
+	    mockApi.setPrecoSimulado("PETR4.SA", 39.0, "-1.2%");
+	
+	    monitorService.verificarAlerta();
+	
+	    // Confere se foi enviado email
+	    assertEquals(0, emailClient.getEmailsEnviados(), "Nenhum e-mail deveria ter sido enviado.");
+	}
+
+	@Test
+	void deveEnviarEmailQuandoAlertaDeBaixaEAtingido() {
+
+	    // Cenário: Alerta para NVDA entre 20 e 17
+	    monitorService.setAlerta(new AlertaPreco("NVDA", 20, 17));
+	    
+	    // Simulação: O preço atual é 16.75
+	    mockApi.setPrecoSimulado("NVDA", 16.75, "-0.5%");
+	
+	    monitorService.verificarAlerta();
+	
+	    // ASSERT
+	    assertEquals(1, emailClient.getEmailsEnviados(), "Um e-mail de alerta de baixa deveria ter sido enviado.");
+	    assertTrue(emailClient.getUltimoAssunto().contains("Alerta de Preço para compra atingido - NVDA"));
+	 }
+}


### PR DESCRIPTION
# Adicionado suporte a testes
- Criação da interface ApiClient para servir como molde para a classe cliente da API FinnhubClient e para a classe teste  MockApiClient.
- Criação das classes MonitorServiceTest e MockApiClient para implementação dos testes de integração
- Modificação da classe emailService para registrar o numero de emails enviados e o ultimo assunto do email (fins de teste)

### Utilização do junit.jupiter para 3 casos de testes de integração:
- Testa se o email é enviado para sugestão da venda, ao alerta ser acionado
- Testa se o email é enviado para sugestão de compra, ao alerta ser acionado
- Testa se o email não é enviado caso o alerta não seja antingido

obs: o destinatário para os testes de email é o destinatário real, caso queira é possível alterar facilmente na classe MonitorServiceTest.